### PR TITLE
Add GitHub Actions CI/CD Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,11 @@ jobs:
       uses: microsoft/setup-msbuild@v2
     
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
+      uses: android-actions/setup-android@v3.2.1
     
-    - name: Install Android SDK Platform 27
-      run: sdkmanager "platforms;android-27"
-    
+    - name: Install Android SDK Platform 24
+      run: sdkmanager "platforms;android-24"
+
     - name: Setup NuGet
       uses: nuget/setup-nuget@v2
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,6 @@ jobs:
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
     
-    - name: Setup Xamarin
-      uses: maxim-lobanov/setup-xamarin@v1.2.1
-      with:
-        mono-version: latest
-        xamarin-android-version: latest
-    
     - name: Setup NuGet
       uses: nuget/setup-nuget@v2
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Android App
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   pull_request:
     branches: [ master ]
   workflow_dispatch:
@@ -33,8 +33,16 @@ jobs:
     - name: Build and Sign APK (Debug)
       run: msbuild Camera2Basic/Camera2Basic.csproj /verbosity:normal /t:Rebuild /t:PackageForAndroid /t:SignAndroidPackage /p:Configuration=Debug
     
+    - name: Decode Keystore
+      if: github.event_name != 'pull_request'
+      run: |
+        $keystore_bytes = [System.Convert]::FromBase64String("${{ secrets.KEYSTORE_FILE }}")
+        [IO.File]::WriteAllBytes("${{ github.workspace }}/android-release-key.keystore", $keystore_bytes)
+    
     - name: Build and Sign APK (Release)
-      run: msbuild Camera2Basic/Camera2Basic.csproj /verbosity:normal /t:Rebuild /t:PackageForAndroid /t:SignAndroidPackage /p:Configuration=Release
+      if: github.event_name != 'pull_request'
+      run: |
+        msbuild Camera2Basic/Camera2Basic.csproj /verbosity:normal /t:Rebuild /t:PackageForAndroid /t:SignAndroidPackage /p:Configuration=Release /p:AndroidKeyStore=true /p:AndroidSigningKeyStore="${{ github.workspace }}/android-release-key.keystore" /p:AndroidSigningKeyAlias="${{ secrets.KEY_ALIAS }}" /p:AndroidSigningKeyPass="${{ secrets.KEY_PASSWORD }}" /p:AndroidSigningStorePass="${{ secrets.KEYSTORE_PASSWORD }}"
     
     - name: Upload Debug APK
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build Android App
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6.0.2
+    
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+    
+    - name: Setup Xamarin
+      uses: maxim-lobanov/setup-xamarin@v1.2.1
+      with:
+        mono-version: latest
+        xamarin-android-version: latest
+    
+    - name: Setup NuGet
+      uses: nuget/setup-nuget@v2
+    
+    - name: Restore NuGet packages
+      run: nuget restore Camera2Basic.sln
+    
+    - name: Build and Sign APK (Debug)
+      run: msbuild Camera2Basic/Camera2Basic.csproj /verbosity:normal /t:Rebuild /t:PackageForAndroid /t:SignAndroidPackage /p:Configuration=Debug
+    
+    - name: Build and Sign APK (Release)
+      run: msbuild Camera2Basic/Camera2Basic.csproj /verbosity:normal /t:Rebuild /t:PackageForAndroid /t:SignAndroidPackage /p:Configuration=Release
+    
+    - name: Upload Debug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: Camera2Basic-Debug
+        path: Camera2Basic/bin/Debug/*-Signed.apk
+        if-no-files-found: warn
+    
+    - name: Upload Release APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: Camera2Basic-Release
+        path: Camera2Basic/bin/Release/*-Signed.apk
+        if-no-files-found: warn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,12 @@ jobs:
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
     
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+    
+    - name: Install Android SDK Platform 27
+      run: sdkmanager "platforms;android-27"
+    
     - name: Setup NuGet
       uses: nuget/setup-nuget@v2
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3.2.1
     
-    - name: Install Android SDK Platform 24
-      run: sdkmanager "platforms;android-24"
+    - name: Install Android SDK Platform 27
+      run: sdkmanager "platforms;android-27"
 
     - name: Setup NuGet
       uses: nuget/setup-nuget@v2

--- a/Camera2Basic/Properties/AndroidManifest.xml
+++ b/Camera2Basic/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="Camera2Basic.Camera2Basic">
-	<uses-sdk android:minSdkVersion="21" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="27" />
 	<application android:label="Camera2Basic"></application>
 	<uses-permission android:name="android.permission.CAMERA" />
 </manifest>


### PR DESCRIPTION
Fixes #1

### Summary
Adds automated build pipeline that compiles and publishes APK artifacts on every push, making it easy to download pre-built APKs without needing to set up a local development environment.

### What's Added
- GitHub Actions workflow that automatically builds Debug and Release APKs
- APK artifacts are uploaded and available for download from the Actions tab
- Workflow can be triggered manually or runs automatically on push/PR

### How to Download APKs
1. Go to the **Actions** tab
2. Click on any completed workflow run
3. Scroll to the **Artifacts** section at the bottom
4. Download `Camera2Basic-Debug` or `Camera2Basic-Release`

The APKs are signed and ready to install on Android devices.